### PR TITLE
Fix colors in dark mode in VS Code and rendered HTML notebooks

### DIFF
--- a/src/session_info2/_repr.py
+++ b/src/session_info2/_repr.py
@@ -103,6 +103,18 @@ def _scrollable_table(inner: str) -> str:
     ).strip()
 
 
+COLORS = dict(
+    fg1="var(--jp-ui-font-color1, var(--vscode-editor-foreground, #212529))",
+    bg0="var(--jp-layout-color0, var(--vscode-editor-background, #f8f9fa))",
+    bg1="var(--jp-layout-color1, var(--vscode-editor-background, #f8f9fa))",
+    bg2="var(--jp-layout-color2, var(--vscode-tree-tableOddRowsBackground, #f1f3f4))",
+)
+
+
+def row_bg(i: int) -> str:
+    return COLORS["bg1" if i % 2 == 0 else "bg2"]
+
+
 def _fmt_html(header: _TableHeader, rows: Iterable[tuple[str, str]]) -> str:
     def strengthen(k: str) -> str:
         return f"<strong>{k}</strong>" if header[0] == "Package" else k
@@ -111,29 +123,16 @@ def _fmt_html(header: _TableHeader, rows: Iterable[tuple[str, str]]) -> str:
     if not rows_list:
         return ""
 
-    header_bg = "var(--jp-layout-color0, var(--vscode-editor-background, #f8f9fa))"
-    header_fg = row_fg = (
-        "var(--jp-ui-font-color1, var(--vscode-editor-foreground, #212529))"
-    )
-
-    def row_bg(i: int) -> str:
-        if i % 2 == 0:
-            return "var(--jp-layout-color2, var(--vscode-editor-background, #f8f9fa))"
-        return (
-            "var(--jp-layout-color3, "
-            "var(--vscode-tree-tableOddRowsBackground, #f1f3f4))"
-        )
-
     trs = "\n".join(
-        f'    <tr style="background-color: {row_bg(i)}; color: {row_fg};">'
+        f'    <tr style="background-color: {row_bg(i)}; color: {COLORS["fg1"]};">'
         f"<td>{strengthen(k)}</td><td>{v}</td></tr>"
         for i, (k, v) in enumerate(rows_list)
     )
 
     th = f"    <tr><th>{header[0]}</th><th>{header[1]}</th></tr>"
     thead_style = (
-        f'style="position: sticky; top: 0; background-color: {header_bg}; '
-        f'color: {header_fg};"'
+        f'style="position: sticky; top: 0; background-color: {COLORS["bg0"]}; '
+        f'color: {COLORS["fg1"]};"'
     )
     thead = f"<thead {thead_style}>\n{th}\n</thead>"
 


### PR DESCRIPTION
Small pet peeve of mine, but the table colors are broken (dark on dark and light on light) in dark mode, especially when "ipywidgets" is not installed. Affects both HTML rendering and VS Code (not tested in other editors). This PR applies CSS variables to rows as well (previously used for the header) with fallback options that ensure readability.

| Before      | After      |
| ------------- | ------------- |
| <img alt="Screenshot 2025-09-12 at 01-25-54 session-info2 documentation" src="https://github.com/user-attachments/assets/ea6d8602-7e87-4cc0-b44e-03099d65c48c" /> | <img alt="Screenshot 2025-09-12 at 01-58-28 session-info2 documentation" src="https://github.com/user-attachments/assets/b69881a9-533e-4713-bd64-64772450c7f8" /> |
| <img alt="Screenshot 2025-09-12 at 01 38 53" src="https://github.com/user-attachments/assets/0fd9e447-956f-496f-aba9-3e989a87e313" /> | <img alt="Screenshot 2025-09-12 at 02 14 16" src="https://github.com/user-attachments/assets/e8862e79-e0fe-4bdf-89fb-a876008b7faf" /> |